### PR TITLE
Added file.sync_data() so the time reported is more accurate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,90 +4,88 @@
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "figlet-rs"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59893843a423e9726b35a3110cd2be573bc9deddc553b0ff286107189b02d1aa"
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core",
 ]
 
 [[package]]
 name = "ssd-benchmark"
 version = "1.1.3"
 dependencies = [
- "figlet-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "figlet-rs",
+ "rand",
 ]
 
 [[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum figlet-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "59893843a423e9726b35a3110cd2be573bc9deddc553b0ff286107189b02d1aa"
-"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
-"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-"checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/sassman/ssd-benchmark-rs"
 exclude = [".ci/*", ".gitignore", ".travis.yml"]
 
 [dependencies]
-rand = "0.7"
-figlet-rs = "0.1"
+rand = "0.7.3"
+figlet-rs = "0.1.3"
 
 [[bin]]
 name = "ssd-benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/sassman/ssd-benchmark-rs"
 exclude = [".ci/*", ".gitignore", ".travis.yml"]
 
 [dependencies]
-rand = "0.7.3"
-figlet-rs = "0.1.3"
+rand = "0.7"
+figlet-rs = "0.1"
 
 [[bin]]
 name = "ssd-benchmark"

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,10 @@ fn write_once(buffer: &[u8]) -> std::io::Result<Duration> {
 
         for _ in 0..TOTAL_SIZE_MB / BUF_SIZE_MB {
             file.write_all(buffer)?;
+            // make sure the data is synced with the disk as the kernel performs
+            // write buffering
+            //
+            // TODO Open the file in O_DSYNC instead to avoid the additional syscall
             file.sync_data()?;
             print!(".");
             stdout().flush()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,18 +164,18 @@ fn main() -> std::io::Result<()> {
 }
 
 fn write_once(buffer: &[u8]) -> std::io::Result<Duration> {
-    let mut write_time = Duration::new(0, 0);
+    let start = Instant::now();
     {
         let mut file = File::create("test").expect("Can't open test file");
 
         for _ in 0..TOTAL_SIZE_MB / BUF_SIZE_MB {
-            write_time += prof! {
-                file.write_all(buffer)?;
-            };
+            file.write_all(buffer)?;
+            file.sync_data()?;
             print!(".");
             stdout().flush()?;
         }
     } // to enforce Drpp on file
+    let write_time = Instant::now() - start;
     remove_file("test")?;
 
     Ok(write_time)


### PR DESCRIPTION
Previously the benchmark would report a disk speed of 1100 MB/s however now I get a speed of 170 MB/s which is much closer to what you would expect this is due to the kernel buffering writes and only committing the data to the disk after a call to file.sync_data()